### PR TITLE
Update pelias-related docs

### DIFF
--- a/pages/en/developers/services-and-apis/2-geocoding-api/address-lookup/index.md
+++ b/pages/en/developers/services-and-apis/2-geocoding-api/address-lookup/index.md
@@ -18,3 +18,14 @@ curl "http://api.digitransit.fi/geocoding/v1/reverse?point.lat=60.199284&point.l
 ### Example to get address for given coordinates (Browser)
 
 http://api.digitransit.fi/geocoding/v1/reverse?point.lat=60.199284&point.lon=24.940540&size=1
+
+### Language preference
+
+http://api.digitransit.fi/geocoding/v1/reverse?point.lat=60.195&point.lon=24.93&lang=sv&size=1
+
+Note, that part of the provided geocoding data does not include Swedish names, and part of the data
+does not specify the language at all. A swedish-speaking person may add a new address entry
+'Fabriksgatan xx, Helsingfors' to OpenStreetMap without specifying the language.
+Address lookup always searches across all documents and returns found items in the preferred
+language if such a language-bound name version is available, otherwise using the default name,
+which in reality can represent any language. Most default names are of course in Finnish.

--- a/pages/en/developers/services-and-apis/2-geocoding-api/address-search/index.md
+++ b/pages/en/developers/services-and-apis/2-geocoding-api/address-search/index.md
@@ -2,7 +2,7 @@
 title: Address search
 ---
 
-Address search can be used to search addresses. Duh.
+Address search can be used to search addresses and place names. Duh.
 
 <!--
 ## Address search APIs
@@ -51,6 +51,7 @@ Supported url parameters:
 | size            | int            | How many results to return
 | boundary.rect   | object         | Search only inside given rectangle
 | boundary.cirlce | object         | Search only inside given circle
+| lang            | string         | Language preference 'fi' or 'sv'.
 
 
 ### Search 'kamppi', return only one result
@@ -70,6 +71,30 @@ curl "http://api.digitransit.fi/geocoding/v1/search?text=kamppi&boundary.rect.mi
 ```
 curl "http://api.digitransit.fi/geocoding/v1/search?text=kamppi&boundary.circle.lat=60.2&boundary.circle.lon=24.936&boundary.circle.radius=30"
 ```
+
+### Language preference
+
+The language preference can be defined using 'lang=xx' parameter, default being 'lang=fi'. Unlike in reverse
+geocoding, the preference has significance for geocoding searches only when multiple languages provide
+an equally good match. An example:
+
+http://api.digitransit.fi/geocoding/v1/search?text=finlandia&lang=sv&size=1
+
+http://api.digitransit.fi/geocoding/v1/search?text=finlandia&lang=fi&size=1
+
+The first search returns Finladia-huset, Helsingfors, and the second one Finlandia-talo, Helsinki.
+Both match the search string 'finlandia' equally well.
+
+In most cases, an identified best match defines the language for the response, overruling the preference. An example:
+
+http://api.digitransit.fi/geocoding/v1/search?text=ulrikasborg&lang=fi
+
+In this case, the search string matches perfectly a swedish place name, and consiquently the result is
+"Ulrikasborg, Helsingfors". In other words, the geocoding API does not act like a translation service.
+
+Note, that part of the provided geocoding data does not include Swedish names, and part of the data
+leaves the language context unknown. This may occasionally cause unexpected errors in language selection.
+
 
 ### Extra documentation
 

--- a/pages/en/developers/services-and-apis/2-geocoding-api/x-service-architecture/index.md
+++ b/pages/en/developers/services-and-apis/2-geocoding-api/x-service-architecture/index.md
@@ -13,7 +13,7 @@ docker:
   dockerfile: https://github.com/HSLdevcom/pelias-api/blob/master/Dockerfile
   imageName: hsldevcom/pelias-api
   buildScript: https://github.com/HSLdevcom/pelias-api/blob/master/build-docker-image.sh
-  runContainer: docker run -d --name pelias-api -p 3100:3100 --link pelias-data-container hsldevcom/pelias-api
+  runContainer: docker run -d --name pelias-api -p 3100:8080 --link pelias-data-container hsldevcom/pelias-api
   accessContainer: curl "http://localhost:3100/v1/search?text=helsinki
 ---
 

--- a/pages/en/developers/services-and-apis/6-data-containers/geocoding-data/index.md
+++ b/pages/en/developers/services-and-apis/6-data-containers/geocoding-data/index.md
@@ -8,8 +8,10 @@ assets:
   dockerHub: https://hub.docker.com/r/hsldevcom/pelias-data-container/
   Dockerfile: https://github.com/HSLdevcom/pelias-data-container/blob/master/Dockerfile
   "Pelias config": https://github.com/HSLdevcom/pelias-data-container/blob/master/pelias.json
+  "ES client": https://github.com/HSLdevcom/dbclient.git
   pelias-nlsfi-places-importer: https://github.com/HSLdevcom/pelias-nlsfi-places-importer.git
-technologies:  
+  pelias-openaddresses-import: https://github.com/HSLdevcom/openaddresses.git
+technologies:
   "SIRI": "http://user47094.vs.easily.co.uk/siri/"
   "GTFS-RT": "https://developers.google.com/transit/gtfs-realtime/"
   "Python": null
@@ -32,27 +34,26 @@ Start by reading (Note that it might not be up-to-date):
 On build time the data is fetched from multiple sources and processed and loaded into ElasticSearch using
 Pelias tools. At high level this is what happens:
 
-1. Download and extract shapefiles from Quattroshapes
+1. Download and extract Finland related shapefiles of administrational areas and regions from WhosOnFirst
 
-2. Download Finnish municipalities NLS and convert them to Quattroshapes format
+2. Download Open Street Map Finland data
 
-3. Download Finland zip codes from Finland Statistics and convert them to Quattroshapes format
+3. Download Openaddresses Finland data (street addresses originating from VRK)
 
-4. Download Open Street Map Finland data
+4. Download NLS places (an extensive list of venues and place names from the National Lands Survey)
 
-5. Download Helsinki, Oulu, and Turku openaddresses data
+5. Start ElasticSearch
 
-6. Download NLS places
+6. Create pelias schema
 
-7. Start ElasticSearch, and Address deduper service
+7. Run NLS places import
 
-8. Create pelias schema and import Quattroshapes data
+8. Run OpenStreetMap import
 
-9. Run NLS places import
+9. Run OpenAddresses import for addresses defined in Swedish
 
-10. Run openaddresses import
+10. Run OpenAddresses import for Finnish addresses and merge fi and sv records for matching addresses
 
-11. Run Open Street Map address import. Data that is already found from openaddresses will be skipped.
 
 
 ### Exploring data
@@ -76,49 +77,24 @@ For Gis data exploration you can use e.g. QGis
 
 ### Open addresses
 - Url: https://openaddresses.io/
-- Datafile: http://data.openaddresses.io.s3.amazonaws.com/runs/37881/fi/18/helsinki.zip
-- Datafile: http://data.openaddresses.io.s3.amazonaws.com/runs/37878/fi/14/oulu.zip
-- Datafile: http://data.openaddresses.io.s3.amazonaws.com/runs/32517/fi/19/turku.zip
-- Types: Address (Helsinki, Oulu, Turku)
+- All datafiles are listed in http://results.openaddresses.io/state.txt. The relevant ones contain a path section /fi/.
+- Types: Address
 
 Open addresses is a open data collaborative to produce global address data around the world. We use addresses from Open addresses as primary data.
 
 ### Open Street Map
 - Url: https://www.openstreetmap.org
 - Datafile: http://download.geofabrik.de/europe/finland-latest.osm.pbf
-- Types: neighbourhood, locality, address, venue, stop
+- Types: address, venue
 
 Our goal is to use as much data from OSM as possible. Unfortunately, at the moment it doesn't contain everything that we need so we have to use other sources also.
 
-### NLS Nimistö
+### NLS Paikat
 - Url: http://www.maanmittauslaitos.fi/digituotteet/nimisto
-- Datafile: http://kartat.kapsi.fi/files/nimisto/paikat/etrs89/gml/paikat_2015_05.zip
-- Types: Place
+- Datafile: http://kartat.kapsi.fi/files/nimisto/paikat/etrs89/gml/paikat_2016_01.zip
+- Types: venue
 
 National Land survey Nimistö ("places") contains place names in Finland. It provides places like "Takalammi".
-
-### Quattroshapes
-- Url: http://quattroshapes.com/
-- Datafile: http://quattroshapes.mapzen.com/quattroshapes/alpha3/FIN.tgz
-- Types: municipality and locality borders
-
-Quattroshapes is a place data source provided by Foursquare. It provides polygon data for places based on Foursquare checkins.
-
-### NLS Kuntajako (Quattroshapes enhancer)
-- Url: http://www.maanmittauslaitos.fi/digituotteet/kuntajako
-- Datafile: http://kartat.kapsi.fi/files/kuntajako/kuntajako_10k/etrs89/gml/TietoaKuntajaosta_2015_10k.zip
-- Types: municipality and locality borders
-
-NOTE! Currently not used any way, we could even remove this.
-
-NLS kuntajako ("municipalities") From National Land Survey contains official Finnish municipality borders and other places that are interesting localities e.g. "Sahalahti". It is used to improve Quattroshapes municipality and locality data.
-
-### Statistics Finland postinumeroalue (Quattroshapes enhancer)
-- Url: http://www.stat.fi/tup/paavo/index.html
-- Data WFS url: http://geo.stat.fi/geoserver/postialue/postialue%3Apno_meri_2015/wfs
-- Types: postal number
-
-Postal address information From Statistics Finland is used to improve Quattroshapes data. This information attaches postal number to address results. e.g. Helsinki, Käpylä is 00610.
 
 
 ## Key service delivery activities


### PR DESCRIPTION
Data-container document was badly outdated, but is now pretty much up-to-date.
In the API side, the new lang parameter is explained in detail, because the standard Pelias docs do not mention it at all (currently a Digitransit-specific feature).