### PR TITLE
HFP documentation fix

### DIFF
--- a/pages/en/developers/apis/1-routing-api/routes/index.md
+++ b/pages/en/developers/apis/1-routing-api/routes/index.md
@@ -171,6 +171,11 @@ on topic `/hfp/v1/journey/ongoing/bus/0012/01511/`**2550**`/`**1**`/Westendinase
    * e.g. *09:03* = `9 * 60 * 60 + 3 * 60` = *32580*
    * If the date in fields `oday` and `tst` is not the same and the departure time (`start`) is earlier than the time in `tst`, add 86400 seconds to departure time
      * This is due to differences in time formats, when vehicles which have departed after midnight have the previous date as operating day   
+     * e.g. 
+       * `tst = 2018-08-`**16**`T00:`**15**`:00Z`
+       * `oday = 2018-08-`**15**
+       * `start = 00:`**10**
+       * → *00:10* = `0 * 60 * 60 + 10 * 60 + 86400` = *87000*
 3. Due to a bug in the vehicle position API, some route ids don't match the route id in the routing API
    * In this case, **fuzzyTrip** query returns `null`
 

--- a/pages/en/developers/apis/1-routing-api/routes/index.md
+++ b/pages/en/developers/apis/1-routing-api/routes/index.md
@@ -169,7 +169,7 @@ on topic `/hfp/v1/journey/ongoing/bus/0012/01511/`**2550**`/`**1**`/Westendinase
    * Direction id *2* in a vehicle position is same as direction id *1* in the Routing API
 2. Departure time must be in seconds
    * e.g. *09:03* = `9 * 60 * 60 + 3 * 60` = *32580*
-   * If the date in fields `oday` and `tst` is not the same, add 86400 seconds to departure time
+   * If the date in fields `oday` and `tst` is not the same and the departure time (`start`) is earlier than the time in `tst`, add 86400 seconds to departure time
      * This is due to differences in time formats, when vehicles which have departed after midnight have the previous date as operating day   
 3. Due to a bug in the vehicle position API, some route ids don't match the route id in the routing API
    * In this case, **fuzzyTrip** query returns `null`


### PR DESCRIPTION
* Fix usage of argument `departure`, when the vehicle has actually departed on the previous date
* Example of case where 86400 seconds must be added to departure time