### PR TITLE
Set HTTP cache headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ FROM node:10-alpine
 
 WORKDIR /opt/digitransit-site
 COPY --from=build /opt/digitransit-site/public ./
+COPY --from=build /opt/digitransit-site/serve.json ./
 RUN yarn global add serve@10.1.1
 EXPOSE 8080
 CMD serve -l 8080

--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,39 @@
+{
+  "headers": [
+    {
+      "source": "**/**.html",
+      "headers": [{
+        "key": "Cache-Control",
+        "value": "public, max-age=0, must-revalidate"
+      }]
+    },
+    {
+      "source": "sw.js",
+      "headers": [{
+        "key": "Cache-Control",
+        "value": "public, max-age=0, must-revalidate"
+      }]
+    },
+    {
+      "source": "static/**",
+      "headers": [{
+        "key": "Cache-Control",
+        "value": "public, max-age=31536000, immutable"
+      }]
+    },
+    {
+      "source": "**/**/!(sw).js",
+      "headers": [{
+	"key": "Cache-Control",
+	"value": "public, max-age=31536000, immutable"
+      }]
+    },
+    {
+      "source": "**/**.css",
+      "headers": [{
+	"key": "Cache-Control",
+	"value": "public, max-age=31536000, immutable"
+      }]
+    }
+  ]
+}


### PR DESCRIPTION
Set HTTP cache headers per https://www.gatsbyjs.org/docs/caching/

This should improve performance and fix site updates being delayed due to caching